### PR TITLE
Add tooltips to some of the more obscure options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kh2fm-randomizer",
-  "version": "0.1.0",
+  "version": "0.2.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -31,9 +31,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.10.2",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
-          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.5.tgz",
+          "integrity": "sha512-otddXKhdNn7d0ptoFRHtMLa8LqDxLYwTjB4nYgM1yy5N6gU/MUf8zqyyLltCH3yAVitBzmwK4us+DD0l/MauAg==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
 	"private": true,
 	"homepage": "https://randomizer.valaxor.com",
 	"dependencies": {
+		"@ant-design/icons": "^4.2.1",
 		"@material-ui/core": "^4.10.2",
 		"antd": "^4.3.3",
 		"axios": "^0.19.2",

--- a/src/components/Seed/SettingSlider.tsx
+++ b/src/components/Seed/SettingSlider.tsx
@@ -1,5 +1,6 @@
-import { Slider } from "antd";
+import { Slider, Tooltip } from "antd";
 import { SliderProps } from "antd/lib/slider";
+import { QuestionCircleOutlined } from "@ant-design/icons"
 import React from "react";
 
 export const Marks = {
@@ -9,14 +10,35 @@ export const Marks = {
 
 export interface SettingSliderProps extends SliderProps {
 	title: string;
+	help?: string;
 }
 
 export const SettingSlider: React.FC<SettingSliderProps> = ({
 	title,
+	help,
 	marks = Marks.onOff,
 	...props
 }) => {
 	const max = Object.values(marks).length - 1;
+
+	if (help !== undefined) {
+		return (
+			<div>
+				<div style={{ textAlign: "center" }}>
+					<Tooltip title={help}>
+						<span>
+							{title}
+							<QuestionCircleOutlined style={{ padding: "0 4px" }} />
+						</span>
+					</Tooltip>
+				</div>
+
+				<div style={{ padding: "0 32px" }}>
+					<Slider max={max} marks={marks} tooltipVisible={false} {...props} />
+				</div>
+			</div>
+		);
+	}
 
 	return (
 		<div>

--- a/src/components/Seed/TabPaneGameModeSettings.tsx
+++ b/src/components/Seed/TabPaneGameModeSettings.tsx
@@ -16,9 +16,17 @@ export const TabPaneGameModeSettings: React.FC = () => {
 	return (
 		<>
 			<div className="tab-pane">
-				<SettingSlider title="Promise Charm" {...mapValue("promiseCharm")} />
+				<SettingSlider 
+					title="Promise Charm" 
+					help="The Promise Charm let's you skip TWTNW if you have all 3 proofs"
+					{...mapValue("promiseCharm")} 
+				/>
 
-				<SettingSlider title="Go Mode" {...mapValue("goMode")} />
+				<SettingSlider 
+					title="Go Mode" 
+					help="Notifies you when you can start the final fights"
+					{...mapValue("goMode")} 
+				/>
 			</div>
 
 			<Divider />
@@ -26,6 +34,7 @@ export const TabPaneGameModeSettings: React.FC = () => {
 			<div className="tab-pane">
 				<SettingSlider
 					title="Shorter Day 5 (Simulated Twilight Town)"
+					help="Let's you skip the 'Wonders missions' on Roxas' Day 5"
 					{...mapValue("shorterDay5")}
 				/>
 			</div>

--- a/src/components/Seed/TabPaneInclude.tsx
+++ b/src/components/Seed/TabPaneInclude.tsx
@@ -18,6 +18,7 @@ export const TabPaneInclude: React.FC = () => {
 		<div className="tab-pane">
 			<SettingSlider
 				title="Keyblade Abilities"
+				help="Support: Keyblade abilities are randomized in their own pool.    Action/Support: Keyblade and Sora's abilities are randomized together."
 				{...mapValue("keybladeAbilities")}
 				marks={{ 0: "Vanilla", 1: "Support", 2: "Action/Support" }}
 			/>

--- a/src/components/Seed/TabPaneSettings.tsx
+++ b/src/components/Seed/TabPaneSettings.tsx
@@ -37,6 +37,7 @@ export const TabPaneSettings: React.FC = () => {
 
 				<SettingSlider
 					title="Leveling"
+					help="Set Max Level (regardless of difficulty)."
 					marks={{ 0: "Level\xa01", 1: "Level\xa050", 2: "Level\xa099" }}
 					{...mapValue("leveling")}
 				/>


### PR DESCRIPTION
- Added the `help` prop that can be used for tooltips to `SettingSlider`. 
- Added `@ant-design/icons` to add a question mark icon where tooltips are used.
- `package-lock` was updated automatically.
- Multiple tooltips added.

If any changes need to be made just let me know. 
Also if you have anything else with which you would like help just let me know.

Discord/Twitch username: XanthosNLD