### PR TITLE
Add a tooltip explaining the Critical Mode option

### DIFF
--- a/src/components/Seed/TabPaneSettings.tsx
+++ b/src/components/Seed/TabPaneSettings.tsx
@@ -33,7 +33,10 @@ export const TabPaneSettings: React.FC = () => {
 					disabled
 				/>
 
-				<SettingSlider title="Critical Mode" {...mapValue("criticalMode")} />
+				<SettingSlider 
+					title="Critical Mode"
+					help="Randomizes abilities normally received at the start of Critical Mode. Disable this when you're not playing on Critical Mode."
+					{...mapValue("criticalMode")} />
 
 				<SettingSlider
 					title="Leveling"


### PR DESCRIPTION
This was requested in the #help channel on the randomizer Discord.